### PR TITLE
Allow mixed-case foregin database column names

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,15 +4,17 @@ THIS PLUGIN IS IN BETA STATUS! BE CAREFULL WITH PRODUCTION ENVIRONMENT!
 
 Users familiar with enrol/db should have no problems configuring this.
 
-Plugin has been tested on 2.3 and 2.6.
+Plugin has been tested on 2.3 and 2.6. and 3.4
 
 This plugin was first developed by Penny Leach <penny@catalyst.net.nz> for Moodle 1.9
-by I modified it to work with Moodle 2.3
+by I modified it to work with Moodle 2.3. Modified by https://github.com/mfuhrmeisterDM for 2.9 and Madhu Avasarala for 3.4
 
 This is my first experience with Moodle plugin development, so your comments are more than
 welcome. Useless to say that you use this piece of code at your own risk :)
 
 In the configuration, "Subject" represent the parent, and "Object" represent the student.
+(You can easily create a table in your database same or separate from Moodle using phpmyadmin using a CSV file.
+In phpmyadmin, click on import and select file and if it is CSV all options are filled in automatically.)
 
 HOW TO INSTALL
 ==============

--- a/lib.php
+++ b/lib.php
@@ -23,7 +23,8 @@ class enrol_dbuserrel_plugin extends enrol_plugin {
      * @param object $instance
      * @return bool
      */
-    public function instance_deleteable($instance) {
+    // the function below had been deprecated and replaced with new function name can_delete_instance
+    public function can_delete_instance($instance) {
         if (!enrol_is_enabled('dbuserrel')) {
             return true;
         }
@@ -79,7 +80,8 @@ function setup_enrolments($verbose = false, &$user=null) {
     }
 
     // we may need a lot of memory here
-    @set_time_limit(0);
+    // the time limit statement below replaces the old @set_time_limit(0)
+    core_php_time_limit::raise();
     raise_memory_limit(MEMORY_HUGE);
 
     // Store the field values in some shorter variable names to ease reading of the code.

--- a/lib.php
+++ b/lib.php
@@ -337,9 +337,9 @@ function enrol_disconnect($extdb) {
    *
    * @param stdClass $user user record
    * @return void
-   */
+   *
   public function sync_user_enrolments($user) {
     $this->setup_enrolments(false, $user);
   }
-
+  */
 } // end of class

--- a/lib.php
+++ b/lib.php
@@ -63,7 +63,9 @@ class enrol_dbuserrel_plugin extends enrol_plugin {
 function setup_enrolments($verbose = false, &$user=null) {
     global $CFG, $DB;
 
-    mtrace('Starting user enrolment synchronisation...');
+    if ($verbose) {
+      mtrace('Starting user enrolment synchronisation...');
+    }
 
     // NOTE: if $this->db_init() succeeds you MUST remember to call
     // $this->enrol_disconnect() as it is doing some nasty vodoo with $CFG->prefix
@@ -210,19 +212,25 @@ function setup_enrolments($verbose = false, &$user=null) {
 				
 				// Get the context of the object
 		$context = context_user::instance($objectusers[$row[$fremoteobject]]);
+            if ($verbose) {
                 mtrace("Information: [" . $row[$fremotesubject] . "] assigning " . $row[$fremoterole] . " to " . $row[$fremotesubject]
-                   . " on " . $row[$fremoteobject]);
+                . " on " . $course->shortname);
+            }
                 // MOODLE 1.X => role_assign($roles[$row->{$fremoterole}]->id, $subjectusers[$row->{$fremotesubject}], 0, $context->id, 0, 0, 0, 'dbuserrel');
 		// MOODLE 2.X => role_assign($roleid, $userid, $contextid, $component = '', $itemid = 0, $timemodified = '') 
 		role_assign($roles[$row[$fremoterole]]->id, $subjectusers[$row[$fremotesubject]], $context->id, 'enrol_dbuserrel', 0, '');
 
             }
 
+        if ($verbose) {
 	    mtrace("Deleting old role assignations");
+        }
             // delete everything left in existing
             foreach ($existing as $key => $assignment) {
                 if ($assignment->component == 'enrol_dbuserrel') {
+            if ($verbose) {
                     mtrace("Information: [$key] unassigning $key");
+            }
                     // MOODLE 1.X => role_unassign($assignment->roleid, $assignment->userid, 0, $assignment->contextid);
 	  	    role_unassign($assignment->roleid, $assignment->userid, $assignment->contextid, 'enrol_dbuserrel', 0);
                 }
@@ -317,6 +325,15 @@ function enrol_disconnect($extdb) {
         }
     }
 
+  /**
+   * Forces synchronisation of user enrolments with external database,
+   * does not create new courses.
+   *
+   * @param stdClass $user user record
+   * @return void
+   */
+  public function sync_user_enrolments($user) {
+    $this->setup_enrolments(false, $user);
+  }
+
 } // end of class
-
-

--- a/settings.php
+++ b/settings.php
@@ -7,6 +7,7 @@
  * @copyright  Penny Leach <penny@catalyst.net.nz>
  * @copyright  Maxime Pelletier <maxime.pelletier@educsa.org>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * DO NOT USE mysql but use mysqli if using php7.x. The default has been changed and mysql option deleted as it crashes
  */
 
 defined('MOODLE_INTERNAL') || die();
@@ -17,9 +18,9 @@ if ($ADMIN->fulltree) {
 
     $settings->add(new admin_setting_heading('enrol_dbuserrel_exdbheader', get_string('settingsheaderdb', 'enrol_dbuserrel'), ''));
 
-    $options = array('', "access","ado_access", "ado", "ado_mssql", "borland_ibase", "csv", "db2", "fbsql", "firebird", "ibase", "informix72", "informix", "mssql", "mssql_n", "mssqlnative", "mysql", "mysqli", "mysqlt", "oci805", "oci8", "oci8po", "odbc", "odbc_mssql", "odbc_oracle", "oracle", "postgres64", "postgres7", "postgres", "proxy", "sqlanywhere", "sybase", "vfp");
+    $options = array('', "access","ado_access", "ado", "ado_mssql", "borland_ibase", "csv", "db2", "fbsql", "firebird", "ibase", "informix72", "informix", "mssql", "mssql_n", "mssqlnative", "mysqli", "mysqlt", "oci805", "oci8", "oci8po", "odbc", "odbc_mssql", "odbc_oracle", "oracle", "postgres64", "postgres7", "postgres", "proxy", "sqlanywhere", "sybase", "vfp");
     $options = array_combine($options, $options);
-    $settings->add(new admin_setting_configselect('enrol_dbuserrel/dbtype', get_string('dbtype', 'enrol_dbuserrel'), get_string('dbtype_desc', 'enrol_dbuserrel'), 'mysql', $options));
+    $settings->add(new admin_setting_configselect('enrol_dbuserrel/dbtype', get_string('dbtype', 'enrol_dbuserrel'), get_string('dbtype_desc', 'enrol_dbuserrel'), 'mysqli', $options));
 
     $settings->add(new admin_setting_configtext('enrol_dbuserrel/dbhost', get_string('dbhost', 'enrol_dbuserrel'), get_string('dbhost_desc', 'enrol_dbuserrel'), 'localhost'));
 

--- a/settings.php
+++ b/settings.php
@@ -6,6 +6,7 @@
  * @subpackage dbuserrel
  * @copyright  Penny Leach <penny@catalyst.net.nz>
  * @copyright  Maxime Pelletier <maxime.pelletier@educsa.org>
+ * @copyright Madhu Avasarala
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * DO NOT USE mysql but use mysqli if using php7.x. The default has been changed and mysql option deleted
  */

--- a/settings.php
+++ b/settings.php
@@ -7,7 +7,7 @@
  * @copyright  Penny Leach <penny@catalyst.net.nz>
  * @copyright  Maxime Pelletier <maxime.pelletier@educsa.org>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * DO NOT USE mysql but use mysqli if using php7.x. The default has been changed and mysql option deleted as it crashes
+ * DO NOT USE mysql but use mysqli if using php7.x. The default has been changed and mysql option deleted
  */
 
 defined('MOODLE_INTERNAL') || die();


### PR DESCRIPTION
Tweak to mfuhrmeisterDM to also allow mixed-case column names in remote database 
